### PR TITLE
Update focus-trap.ts

### DIFF
--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -205,4 +205,4 @@ export class FocusTrap extends HTMLElement implements IFocusTrap {
 	}
 }
 
-window.customElements.define("focus-trap", FocusTrap);
+if (!window.customElements.get('focus-trap')) customElements.define('focus-trap', FocusTrap);


### PR DESCRIPTION
Conditionally calls define of the attribute.

We have a case where we load weightless into lit elements and then using them in an angular project, when loading different elements using weightless this library causes a conflict by trying to define the same custom element more than once