### PR TITLE
fix: prevent multiple registers in customElement registry

### DIFF
--- a/src/lib/focus-trap.ts
+++ b/src/lib/focus-trap.ts
@@ -204,4 +204,7 @@ export class FocusTrap extends HTMLElement implements IFocusTrap {
 	}
 }
 
-window.customElements.define("focus-trap", FocusTrap);
+if (!window.customElements.get("focus-trap")) {
+	window.customElements.define("focus-trap", FocusTrap);
+}
+	


### PR DESCRIPTION
If the lib is included multiple times - e.g in a micro-frontend architecture, trying to register the same component in the custom element registry results in a runtime error

this PR adds a check if the component is already registered to prevent the multiple register error